### PR TITLE
Fix for extra quote character appearing in team member UUID's strings during team update operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/clivern/terraform-provider-lynx
 
-go 1.21
+go 1.22.0
+
 toolchain go1.22.5
 
 require (
@@ -15,6 +16,7 @@ require (
 	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-plugin v1.6.2 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
+	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.4 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/C
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/terraform-plugin-framework v1.13.0 h1:8OTG4+oZUfKgnfTdPTJwZ532Bh2BobF4H+yBiYJ/scw=
 github.com/hashicorp/terraform-plugin-framework v1.13.0/go.mod h1:j64rwMGpgM3NYXTKuxrCnyubQb/4VKldEKlcG8cvmjU=
+github.com/hashicorp/terraform-plugin-framework-validators v0.16.0 h1:O9QqGoYDzQT7lwTXUsZEtgabeWW96zUBh47Smn2lkFA=
+github.com/hashicorp/terraform-plugin-framework-validators v0.16.0/go.mod h1:Bh89/hNmqsEWug4/XWKYBwtnw3tbz5BAy1L1OgvbIaY=
 github.com/hashicorp/terraform-plugin-go v0.26.0 h1:cuIzCv4qwigug3OS7iKhpGAbZTiypAfFQmw8aE65O2M=
 github.com/hashicorp/terraform-plugin-go v0.26.0/go.mod h1:+CXjuLDiFgqR+GcrM5a2E2Kal5t5q2jb0E3D57tTdNY=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -7,7 +7,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/clivern/terraform-provider-lynx/sdk"
 
@@ -110,14 +109,11 @@ func (r *TeamResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	membersList := data.Members.Elements()
-
-	members := make([]string, 0, len(membersList))
-
-	for i := 0; i < len(membersList); i++ {
-		member := membersList[i]
-
-		members = append(members, strings.Trim(member.String(), "\""))
+	var members []string
+	diagInfo := data.Members.ElementsAs(ctx, &members, false)
+	resp.Diagnostics.Append(diagInfo...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	newTeam := sdk.Team{
@@ -188,19 +184,15 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	membersList := data.Members.Elements()
-
-	members := make([]string, 0, len(membersList))
-
-	for i := 0; i < len(membersList); i++ {
-		member := membersList[i]
-
-		members = append(members, member.String())
+	var members []string
+	diagInfo := data.Members.ElementsAs(ctx, &members, false)
+	resp.Diagnostics.Append(diagInfo...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Update the team using the UpdateTeam method

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -10,11 +10,13 @@ import (
 
 	"github.com/clivern/terraform-provider-lynx/sdk"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -67,6 +69,9 @@ func (r *TeamResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				MarkdownDescription: "Team's members",
 				ElementType:         types.StringType,
 				Required:            true,
+				Validators: []validator.List{
+					listvalidator.NoNullValues(),
+				},
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,


### PR DESCRIPTION
If a team has a user added or deleted to it, the operation will always fail with a 400 error returned from lynx. This is caused by malformed team UUID in the json sent to Lynx; the team UUID's has an extraneous double quote in it. 

This appears to have been semi caught with the team creation as there's an additional trim command with team strings being extracted from terraform, as there's an explicit call to trim off quotes there, but not in update. 

This MR attempts to fix the issue by utilizing the Terraform SDK's ListValue.ElementAs method, passing in a pointer to a string array for for the call to utilize. This returns the strings in their raw properly formatted as strings.  ElementsAs returns a Diagnostics object which can be added to the response in case of some kind of error, which allows terraform to handle it in a more elegant fashion. 

For consistency's sake, both create and update for teams have been updated to utilize this method. 

This introduces a potential problem where a null value from terraform state can cause the call to fail. The diagnostic message from the ElementAs method implies that it is a plugin failure rather then an invalid value being passed in. Hence we also add in a Validator object in the schema that adds a NotNull check for all elements of members. When a null is passed in here, the validate stage of terraform will explicitly give an error informing the user of the invalid null value. 